### PR TITLE
Remove freeze and wipe functionality

### DIFF
--- a/contracts/PYUSDImplementation.sol
+++ b/contracts/PYUSDImplementation.sol
@@ -413,27 +413,27 @@ contract PYUSDImplementation {
      * @dev Freezes an address balance from being transferred.
      * @param _addr The new address to freeze.
      */
-    function freeze(address _addr) public onlyAssetProtectionRole {
+    /* function freeze(address _addr) public onlyAssetProtectionRole {
         require(!frozen[_addr], "address already frozen");
         frozen[_addr] = true;
         emit AddressFrozen(_addr);
-    }
+    } */
 
     /**
      * @dev Unfreezes an address balance allowing transfer.
      * @param _addr The new address to unfreeze.
      */
-    function unfreeze(address _addr) public onlyAssetProtectionRole {
+    /* function unfreeze(address _addr) public onlyAssetProtectionRole {
         require(frozen[_addr], "address already unfrozen");
         frozen[_addr] = false;
         emit AddressUnfrozen(_addr);
-    }
+    } */
 
     /**
      * @dev Wipes the balance of a frozen address, and burns the tokens.
      * @param _addr The new frozen address to wipe.
      */
-    function wipeFrozenAddress(address _addr) public onlyAssetProtectionRole {
+    /* function wipeFrozenAddress(address _addr) public onlyAssetProtectionRole {
         require(frozen[_addr], "address is not frozen");
         uint256 _balance = balances[_addr];
         balances[_addr] = 0;
@@ -441,16 +441,16 @@ contract PYUSDImplementation {
         emit FrozenAddressWiped(_addr);
         emit SupplyDecreased(_addr, _balance);
         emit Transfer(_addr, address(0), _balance);
-    }
+    } */
 
     /**
     * @dev Gets whether the address is currently frozen.
     * @param _addr The address to check if frozen.
     * @return A bool representing whether the given address is frozen.
     */
-    function isFrozen(address _addr) public view returns (bool) {
+    /* function isFrozen(address _addr) public view returns (bool) {
         return frozen[_addr];
-    }
+    } */
 
     // SUPPLY CONTROL FUNCTIONALITY
 


### PR DESCRIPTION
Comments out the "freeze", "wipe balance of frozen accounts", and "query whether and address is frozen" functionality, thereby reducing the size of the contract for significant gas savings.